### PR TITLE
Enhanced checking of the requirements...

### DIFF
--- a/bin/gifify
+++ b/bin/gifify
@@ -87,28 +87,34 @@ function missingDependency(command, dependencies) {
 // are installed with the correct dependencies. For example, to make subtitles
 // work, ffmpeg needs to be compiled with `enable-libass`.
 function checkRequirements() {
-  var required = {
-    'ffmpegx': { 'args' : '-version', 'needs': ['enable-libass', 'enable-libfontconfig'] },
-    'convert': { 'args': '--version', 'needs': ['fontconfig'] },
-    'gifsicle': { 'args': '-h', 'needs': ['lossy'] }
-  }
-  var promises = Object.keys(required).map(function (key) {
-    var options = required[key];
-    return new Promise(function find(resolve, reject) {
-      exec([key, options['args']].join(' '), function(error, stdout, stderr) {
-        if (error) return reject(notInstalledMessage(key));
+  var required = [
+    {'bin': 'ffmpeg', 'args' : '-version', 'needs': ['enable-libass', 'enable-libfontconfig']},
+    {'bin': 'convert', 'args': '--version', 'needs': ['fontconfig']},
+    {'bin': 'gifsicle', 'args': '-h', 'needs': ['lossy']}
+  ]
 
-        var ok = (options['needs'] || []).every(function(req) {
-          return new RegExp(req, 'i').test(stdout);
-        });
-        if (ok) {
-          return resolve();
-        } else {
-          return reject(missingDependency(key, options['needs']));
-        }
-      });
+  return Promise.all(required.map(checkRequirement));
+}
+
+// Takes a `obj` which should have three keys available:
+//       bin - The name of the binary to execute
+//       args - The arguments that are passed to the binary
+//       needs - Strings to look for in the output of `bin` fed `args`
+//
+// Returns a Promise
+function checkRequirement(obj) {
+  return new Promise(function find(resolve, reject) {
+    exec([obj.bin, obj.args].join(' '), function(error, stdout, stderr) {
+      if (error) return reject(notInstalledMessage(obj.bin));
+
+      var ok = (obj.needs || []).every(function(req) {
+                 return new RegExp(req, 'i').test(stdout);
+               });
+      if (ok) {
+        return resolve();
+      } else {
+        return reject(missingDependency(obj.bin, obj.needs));
+      }
     });
   });
-
-  return Promise.all(promises);
 }

--- a/bin/gifify
+++ b/bin/gifify
@@ -7,6 +7,7 @@ var Promise = require('promise');
 var whereis = require('whereis');
 var exec = require('child_process').exec;
 var util = require('util');
+var colors = require('colors');
 
 var gifify = require('../');
 
@@ -74,15 +75,12 @@ function encode() {
   outputStream.on('error', abort.bind(null));
 }
 
-function ansiRed(string) {
-  return "\033[31m" + string + "\033[91m";
-}
 function notInstalledMessage(command) {
-  return ansiRed(util.format("\tCould not find %s. Is it installed?", command));
+  return colors.red(util.format("\tCould not find %s. Is it installed?", command));
 }
 
 function missingDependency(command, dependencies) {
-  return ansiRed(util.format("\t%s needs %s", command, dependencies.join(", ")));
+  return colors.red(util.format("\t%s needs %s", command, dependencies.join(", ")));
 }
 
 // This will check both if the required applications are installed, and if they
@@ -90,7 +88,7 @@ function missingDependency(command, dependencies) {
 // work, ffmpeg needs to be compiled with `enable-libass`.
 function checkRequirements() {
   var required = {
-    'ffmpeg': { 'args' : '-version', 'needs': ['enable-libass', 'enable-libfontconfig'] },
+    'ffmpegx': { 'args' : '-version', 'needs': ['enable-libass', 'enable-libfontconfig'] },
     'convert': { 'args': '--version', 'needs': ['fontconfig'] },
     'gifsicle': { 'args': '-h', 'needs': ['lossy'] }
   }

--- a/bin/gifify
+++ b/bin/gifify
@@ -76,11 +76,12 @@ function encode() {
 }
 
 function notInstalledMessage(command) {
-  return colors.red(util.format("\tCould not find %s. Is it installed?", command));
+  var readMe = "https://github.com/vvo/gifify#requirements";
+  return colors.red(util.format("Could not find %s. Is it installed?\n\nMore info: %s", command, readMe));
 }
 
 function missingDependency(command, dependencies) {
-  return colors.red(util.format("\t%s needs %s", command, dependencies.join(", ")));
+  return colors.red(util.format("%s needs %s", command, dependencies.join(", ")));
 }
 
 // This will check both if the required applications are installed, and if they

--- a/bin/gifify
+++ b/bin/gifify
@@ -5,6 +5,8 @@ var path = require('path');
 var program = require('commander');
 var Promise = require('promise');
 var whereis = require('whereis');
+var exec = require('child_process').exec;
+var util = require('util');
 
 var gifify = require('../');
 
@@ -72,19 +74,43 @@ function encode() {
   outputStream.on('error', abort.bind(null));
 }
 
-function checkRequirements() {
-  var requirements = ['ffmpeg', 'convert', 'gifsicle'];
-  return Promise.all(requirements.map(findRequirement));
+function ansiRed(string) {
+  return "\033[31m" + string + "\033[91m";
+}
+function notInstalledMessage(command) {
+  return ansiRed(util.format("\tCould not find %s. Is it installed?", command));
 }
 
-function findRequirement(programName) {
-  return new Promise(function find(resolve, reject) {
-    whereis(programName, function found(err) {
-      if (err) {
-        return reject(err);
-      }
+function missingDependency(command, dependencies) {
+  return ansiRed(util.format("\t%s needs %s", command, dependencies.join(", ")));
+}
 
-      resolve();
+// This will check both if the required applications are installed, and if they
+// are installed with the correct dependencies. For example, to make subtitles
+// work, ffmpeg needs to be compiled with `enable-libass`.
+function checkRequirements() {
+  var required = {
+    'ffmpeg': { 'args' : '-version', 'needs': ['enable-libass', 'enable-libfontconfig'] },
+    'convert': { 'args': '--version', 'needs': ['fontconfig'] },
+    'gifsicle': { 'args': '-h', 'needs': ['lossy'] }
+  }
+  var promises = Object.keys(required).map(function (key) {
+    var options = required[key];
+    return new Promise(function find(resolve, reject) {
+      exec([key, options['args']].join(' '), function(error, stdout, stderr) {
+        if (error) return reject(notInstalledMessage(key));
+
+        var ok = (options['needs'] || []).every(function(req) {
+          return new RegExp(req, 'i').test(stdout);
+        });
+        if (ok) {
+          return resolve();
+        } else {
+          return reject(missingDependency(key, options['needs']));
+        }
+      });
     });
   });
+
+  return Promise.all(promises);
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "moment": "2.8.3",
     "moment-duration-format": "1.3.0",
     "promise": "6.0.1",
-    "whereis": "0.4.0"
+    "whereis": "0.4.0",
+    "colors": "1.0.3"
   }
 }


### PR DESCRIPTION
I tried rendering a gif with subtitles and ran into an error like this:

```
convert.im6: no decode delegate for this image format `/tmp/magick-dmhxdNv4' @ error/constitute.c/ReadImage/544.
convert.im6: no images defined `gif:-' @error/convert.c/ConvertImageCommand/3044.
```

This is because `convert` doesn't get any input from `ffmpeg` and this
was caused because `ffmpeg` was not compiled with the `libass` flag.

So I added some extra dependency checking in the `checkRequirements`
call.

This does seem to add roughly 0.02s to the app, based on my
extensive (read: running the app with `time`, like an animal).

The resulting gif in all its glory:

![WAT](https://pile.pjaspers.com/bob_wat.gif)