### PR TITLE
On windows ImageMagick don't need 'fontconfig'

### DIFF
--- a/bin/gifify
+++ b/bin/gifify
@@ -90,9 +90,14 @@ function missingDependency(command, dependencies) {
 function checkRequirements() {
   var required = [
     {'bin': 'ffmpeg', 'args' : '-version', 'needs': ['libass', 'fontconfig']},
-    {'bin': 'convert', 'args': '--version', 'needs': ['fontconfig']},
     {'bin': 'gifsicle', 'args': '-h', 'needs': ['lossy']}
-  ]
+  ];
+  
+  if(process.platform != 'win32') {
+    required.push({'bin': 'convert', 'args': '--version', 'needs': ['fontconfig']});
+  } else {
+    required.push({'bin': 'convert', 'args': '--version', 'needs': []});
+  }
 
   return Promise.all(required.map(checkRequirement));
 }


### PR DESCRIPTION
The module wasn't working on Windows because actually all ImageMagick binaries for windows don't include the 'fontconfig' feature (there is the automatic font discovery).
To make the module cross-OS i've removed the requirement of ImageMagick for 'fontconfig' only for win32 OS. 

Now it works.