### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ gifify screencast.mkv -o screencast.gif --resize 800:-1
 
 Before using gifify, please install:
 
-- [Node.js](https://nodejs.or) (`$ brew install node`)
-- [FFmpeg](http://ffmpeg.org/) [🐓🐓🐓🐓](http://en.wikipedia.org/wiki/FFmpeg#History) (`$ brew install ffmpeg --with-libass --with-fontconfig`)
-- [convert](http://www.imagemagick.org/script/convert.php), the famous [ImageMagick](http://www.imagemagick.org/) (`$ brew install imagemagick --with-fontconfig`)
-- [pornel/giflossy](https://github.com/pornel/giflossy/releases), it's a [gifsicle](http://www.lcdf.org/gifsicle/) fork (waiting for [gifsicle#16](https://github.com/kohler/gifsicle/pull/16) to be merged). Download the zip release file, make the corresponding binary available in your $PATH.
+- [Node.js](https://nodejs.or) (`brew install node`)
+- [FFmpeg](http://ffmpeg.org/) [🐓🐓🐓🐓](http://en.wikipedia.org/wiki/FFmpeg#History) (`brew install ffmpeg --with-libass --with-fontconfig`)
+- [convert](http://www.imagemagick.org/script/convert.php), the famous [ImageMagick](http://www.imagemagick.org/) (`brew install imagemagick --with-fontconfig`)
+- [pornel/giflossy](https://github.com/pornel/giflossy/releases), it's a [gifsicle](http://www.lcdf.org/gifsicle/) fork (waiting for [gifsicle#16](https://github.com/kohler/gifsicle/pull/16) to be merged). Download the [latest zip release file](https://github.com/pornel/giflossy/releases) and make the corresponding binary available in your $PATH. For example:
+
+ ```shell
+curl -J -L https://github.com/pornel/giflossy/releases/download/lossy%2F1.82.1/gifsicle-1.82.1-lossy.zip  | tar -xzv --strip-components 1 --include=mac/gifsicle - -C /usr/local/bin/
+```
 
 You can also use the [gifify Docker image](https://github.com/maxogden/gifify-docker) which comes with everything installed.
 


### PR DESCRIPTION
Updated installation instructions for gifsicle (motived by https://gist.github.com/SlexAxton/4989674#gistcomment-1476312).

The example from comment above uses wget. I prefer to use curl of wget. I don't have wget installed on my system. Not sure if you want to have instructions for both (isn't curl ubiquitous?).