### PR TITLE
Fix Regression: make gifs always loop by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ function computeGifsicleArgs(opts) {
     '--no-warnings'
   ];
 
-  if (!opts.loop) {
+  if (opts.loop === false) {
     args.push('--no-loopcount');
   }
 


### PR DESCRIPTION
The changes introduced when implementing the --no-loop argument caused gifs to not loop by default, when using the node package directly (gifs were still looping by default when using gifify's cli)