### PR TITLE
Add --reverse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gifify screencast.mkv -o screencast.gif --resize 800:-1
 - programmatic JavaScript ([Node.JS](http://nodejs.org/)) [stream](http://nodejs.org/api/stream.html) interface
 - unix friendly, supports `stdin` & `stdout`
 - optimized! uses [pornel/giflossy](https://github.com/pornel/giflossy) to generate light GIFS
-- lots of options: movie speed, fps, colors, compression, resize, from & to, subtitles
+- lots of options: movie speed, fps, colors, compression, resize, reverse, from & to, subtitles
 - no temp files used, everything happens in memory
 - fast! Extracting a 5 seconds GIF from the middle of a 2 hours movie takes less than 20 seconds
 
@@ -56,6 +56,7 @@ npm install -g gifify
     --fps <n>               Frames Per Second, defaults to 10
     -o, --output <file>     Output file, defaults to stdout
     --resize <W:H>          Resize output, use -1 when specifying only width or height. `350:100`, `400:-1`, `-1:200`
+    --reverse               Reverses movie
     --speed <n>             Movie speed, defaults to 1
     --subtitles <filepath>  Subtitle filepath to burn to the GIF
     --text <string>         Add some text at the bottom of the movie

--- a/bin/gifify
+++ b/bin/gifify
@@ -21,6 +21,7 @@ var options =
     .option('--fps <n>', 'Frames Per Second, defaults to 10', parseFloat, 10)
     .option('-o, --output <file>', 'Output file, defaults to stdout')
     .option('--resize <W:H>', 'Resize output, use -1 when specifying only width or height. `350:100`, `400:-1`, `-1:200`')
+    .option('--reverse', 'Reverses movie')
     .option('--speed <n>', 'Movie speed, defaults to 1', parseFloat, 1)
     .option('--subtitles <filepath>', 'Subtitle filepath to burn to the GIF')
     .option('--text <string>', 'Add some text at the bottom of the movie')

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function computeFFmpegArgs(opts) {
   // framerate
   args.push('-r', opts.fps);
 
-  if (opts.resize || opts.subtitles) {
+  if (opts.resize || opts.subtitles || opts.reverse) {
     // filters
     args.push('-vf');
 
@@ -114,6 +114,10 @@ function computeFFmpegArgs(opts) {
 
     if (opts.subtitles !== undefined) {
       filters.push('subtitles=' + opts.subtitles);
+    }
+
+    if (opts.reverse !== undefined) {
+      filters.push('reverse');
     }
 
     args.push(filters.join(','));


### PR DESCRIPTION
A project I am working on needed the ability to reverse gifs along with the other features that Gifify currently offers.

I didn't see this in the issues, but I thought I'd submit this feature just in case anyone needs reverse in the future. Luckily, ffmpeg already has a reverse filter implemented so it only took a few lines to add.